### PR TITLE
fix: update rules "Last Updated" date

### DIFF
--- a/src/rules.md
+++ b/src/rules.md
@@ -4,7 +4,7 @@ title: SwitchCraft Rules
 
 # {{ $frontmatter.title }}
 
-<Badge text="Last updated: January 17th, 2023" type="tip" />
+<Badge text="Last updated: February 25th, 2023" type="tip" />
 Above all the rules, please use common sense, and be nice to other people.
 
 <div class="rules-list">


### PR DESCRIPTION
Commit 92623649a90aa84b66b33931f7eff6623256864f created rule 5.7, but apparently forgot to change the "Last Updated" date. This changes the date to Feb 25th (which is the UTC time; the true last update date was Feb 24th for many users due to timezones). In the future this might need to either be automatically updated, removed, or rules-updaters will need to start remembering to change this date.