### PR TITLE
Replace Fandom links with new Minecraft Wiki

### DIFF
--- a/src/chatbox/switchchat.md
+++ b/src/chatbox/switchchat.md
@@ -393,7 +393,7 @@ The Discord user object represents a user on Discord.
 ([Websocket API docs](https://docs.sc3.io/chatbox/websocket.html#raw-json-text-object) &ndash;
 [API reference](https://docs.sc3.io/library/switchchat/interfaces/RenderedTextObject.html))
 
-Minecraft's serialised [raw JSON text format](https://minecraft.fandom.com/wiki/Raw_JSON_text_format). See the [SwitchCraft documentation](https://docs.sc3.io/chatbox/websocket.html#raw-json-text-object) for more information on how this is used.
+Minecraft's serialised [raw JSON text format](https://minecraft.wiki/w/Raw_JSON_text_format). See the [SwitchCraft documentation](https://docs.sc3.io/chatbox/websocket.html#raw-json-text-object) for more information on how this is used.
 
 ### FormattingMode
 
@@ -402,5 +402,5 @@ Minecraft's serialised [raw JSON text format](https://minecraft.fandom.com/wiki/
 The mode to use for outgoing chatbox messages (`.say()`, `.tell()`).
 
 - markdown - Discord-like [Markdown syntax](https://support.discord.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline-). Supports URLs, but not colours.
-- format - Minecraft-like [formatting codes](https://minecraft.fandom.com/wiki/Formatting_codes) using ampersands (e.g. `&e` for yellow). Supports colours, but not URLs.
+- format - Minecraft-like [formatting codes](https://minecraft.wiki/w/Formatting_codes) using ampersands (e.g. `&e` for yellow). Supports colours, but not URLs.
 

--- a/src/chatbox/websocket.md
+++ b/src/chatbox/websocket.md
@@ -256,7 +256,7 @@ Sends a message to the in-game public chat.
 * `mode` - (*optional*) The formatting mode to use. You can use these formatting modes:
   * `markdown` - (**default**) Discord-like [Markdown syntax](https://support.discord.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline-).
     Supports URLs, but not colours.
-  * `format` - Minecraft-like [formatting codes](https://minecraft.fandom.com/wiki/Formatting_codes) using ampersands
+  * `format` - Minecraft-like [formatting codes](https://minecraft.wiki/w/Formatting_codes) using ampersands
     (e.g. `&e` for yellow). Supports colours, but not URLs.
 * `id` - (*optional*) Numeric ID to identify this message. If specified, the [`success`](#success-packet) response 
   packet will contain this ID so you can identify when this specific message has been sent.
@@ -287,7 +287,7 @@ is not online in-game, you will receive the `unknown_user` error.
 * `mode` - (*optional*) The formatting mode to use. You can use these formatting modes:
   * `markdown` - (**default**) Discord-like [Markdown syntax](https://support.discord.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline-).
     Supports URLs, but not colours.
-  * `format` - Minecraft-like [formatting codes](https://minecraft.fandom.com/wiki/Formatting_codes) using ampersands
+  * `format` - Minecraft-like [formatting codes](https://minecraft.wiki/w/Formatting_codes) using ampersands
     (e.g. `&e` for yellow). Supports colours, but not URLs.
 * `id` - (*optional*) Numeric ID to identify this message. If specified, the [`success`](#success-packet) response
   packet will contain this ID so you can identify when this specific message has been sent.
@@ -865,7 +865,7 @@ Example of a Discord user object:
 
 Messages will be accompanied by their string representation (`text`) as well as their in-game rich text representation
 (`renderedText`). The rendered text is serialised as a JSON object conforming to the Minecraft 
-[raw JSON text format](https://minecraft.fandom.com/wiki/Raw_JSON_text_format). As rendered text is generated
+[raw JSON text format](https://minecraft.wiki/w/Raw_JSON_text_format). As rendered text is generated
 automatically by the server, it is not guaranteed that you will receive the same JSON for every version, and the
 serialised form may not be optimal or compact.
 

--- a/src/whats-new/sc-peripherals.md
+++ b/src/whats-new/sc-peripherals.md
@@ -165,7 +165,7 @@ A 2dj file is a JSON file with the following structure:
 
 Poster palettes are limited to 63 colors plus one transparent color. The first color in the palette (index 0) is
 fully transparent, and the remaining 63 colors (index 1 onward) are fully opaque but customizable. By default, the
-posters use the same palette as [vanilla maps](https://minecraft.fandom.com/wiki/Map_item_format#Base_colors), e.g.
+posters use the same palette as [vanilla maps](https://minecraft.wiki/w/Map_item_format#Base_colors), e.g.
 0 is NONE, 1 is <ColorName color="rgb(127, 178, 56)">GRASS</ColorName>, 
 2 is <ColorName color="rgb(247, 233, 163)">SAND</ColorName>, etc.
 


### PR DESCRIPTION
Since everyone is migrating from minecraft.fandom.com to the new one at minecraft.wiki, links should open the new one instead.
